### PR TITLE
fix: move safe area insets from root container to inner elements to restore mobile scrolling

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -529,15 +529,20 @@ html, body {
    For devices with notch / Dynamic Island / home indicator
    ============================================= */
 
-/* Main app shell: pad for safe areas on all edges */
+/* Main app shell: only horizontal safe areas on root to preserve scroll chain */
 .flex.flex-col.md\:flex-row.w-screen.h-screen {
-  /* Top padding for notch / Dynamic Island */
-  padding-top: env(safe-area-inset-top);
-  /* Bottom padding for home indicator */
-  padding-bottom: env(safe-area-inset-bottom);
-  /* Left/Right for landscape orientation */
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+}
+
+/* Top safe area on the scheduler controls header */
+.scheduler > .info {
+  padding-top: env(safe-area-inset-top);
+}
+
+/* Bottom safe area inside the scrollable weeks container */
+.weeks {
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* Hot toast notifications — offset from safe area top */
@@ -563,7 +568,6 @@ html, body {
   }
   .flex.flex-col.md\:flex-row.w-screen.h-screen {
     height: -webkit-fill-available;
-    min-height: -webkit-fill-available;
   }
   .flex.flex-col.justify-center.items-center.min-h-screen.w-screen {
     min-height: -webkit-fill-available;


### PR DESCRIPTION
Vertical safe area padding on the fixed-height root container (h-screen + overflow-hidden)
broke the scroll chain on mobile. The padding reduced the content area, causing child
elements with h-full to miscalculate their heights and preventing overflow-auto from
working in the week-view.

- Move padding-top to .scheduler > .info (controls header)
- Move padding-bottom into .weeks (inside the scrollable area)
- Keep only horizontal safe area padding on root (doesn't affect vertical scroll)
- Remove min-height: -webkit-fill-available which also constrained the scroll chain

https://claude.ai/code/session_01UdGRQjz94hN8zYMRuhCcBD