### PR TITLE
fix: restore mobile scrolling broken by safe area insets

### DIFF
--- a/src/app/_components/scheduler/scheduler.component.html
+++ b/src/app/_components/scheduler/scheduler.component.html
@@ -7,7 +7,7 @@
         </app-scheduler-controls>
     </div>
 </div>
-<div class="flex flex-col h-full overflow-hidden">
+<div class="flex flex-col flex-1 min-h-0 overflow-hidden">
     <app-week-view [currentWeekStart]="currentWeekStart" [currentWeek]="currentWeek" [mealPlan]="mealPlan"
         [recipes]="recipes" (dragOver)="onDragOver($event)" (drop)="onDrop($event)"
         (addRecipe)="onAddRecipe($event)">

--- a/src/app/_components/week-view/week-view.component.html
+++ b/src/app/_components/week-view/week-view.component.html
@@ -1,5 +1,5 @@
 @if (currentWeekStart) {
-<div class="weeks h-full justify-stretch flex flex-col overflow-auto md:overflow-hidden w-full md:gap-4 md:p-4">
+<div class="weeks flex-1 min-h-0 justify-stretch flex flex-col overflow-auto md:overflow-hidden w-full md:gap-4 md:p-4">
     @for (weekData of weeks; track weekData.weekNumber; let i = $index) {
     <div class="flex flex-col flex-none md:flex-1 md:min-h-0 week-card" [ngClass]="i > 0 ? 'hidden md:flex' : ''">
         <div class="sticky top-0 z-20

--- a/src/app/_components/week-view/week-view.component.scss
+++ b/src/app/_components/week-view/week-view.component.scss
@@ -1,5 +1,6 @@
 :host {
     display: flex;
+    flex-direction: column;
     flex: 1;
     min-height: 0;
     width: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -543,6 +543,7 @@ html, body {
 /* Bottom safe area inside the scrollable weeks container */
 .weeks {
   padding-bottom: env(safe-area-inset-bottom);
+  -webkit-overflow-scrolling: touch;
 }
 
 /* Hot toast notifications — offset from safe area top */


### PR DESCRIPTION
The content wrapper in scheduler used h-full (100% parent height) which
overflows when the .info header has safe-area-inset-top padding, causing
overflow-hidden to clip the scrollable weeks container. Changed to flex-1
min-h-0 to properly fill remaining space. Also fixed the height chain
through week-view by using flex-direction: column and flex-1 instead of
h-full for reliable height resolution in nested flex contexts.

https://claude.ai/code/session_01KHQETaoNrZmJJEhRky28Mo