### PR TITLE
Add explicit background colors to html and theme root elements

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -19,7 +19,10 @@
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
   }
 
-  html { color-scheme: light; }
+  html {
+    color-scheme: light;
+    background-color: #fafaf9;
+  }
 
   body {
     background-color: #fafaf9;
@@ -42,6 +45,7 @@
    ============================================= */
 .light {
   color-scheme: light;
+  background-color: #fafaf9 !important;
 
   body {
     background-color: #fafaf9 !important;
@@ -295,6 +299,7 @@ app-theme-toggle .dropdown-menu {
    ============================================= */
 .dark {
   color-scheme: dark;
+  background-color: #0c0a09 !important;
 
   * { border-color: #292524 !important; }
 


### PR DESCRIPTION
## Summary
This PR adds explicit background color declarations to the HTML element and theme root classes to ensure consistent background styling across light and dark themes.

## Key Changes
- Added `background-color: #fafaf9` to the `html` element in the light theme
- Added `background-color: #fafaf9 !important` to the `.light` class
- Added `background-color: #0c0a09 !important` to the `.dark` class

## Implementation Details
These changes ensure that background colors are applied at the root level of the document, preventing potential color scheme mismatches when switching between themes. The `!important` flags on the theme classes guarantee that the specified background colors take precedence, providing a more robust theming system.

https://claude.ai/code/session_01FzeT7FbUkjBTHhjdz1VSBt