### PR TITLE
feat(deploy): Coolify-ready build & SPA fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 npm-debug.log
 yarn-error.log
 
+# Coolify build artifacts
+/server/public
+/server/.output
+/server/.nuxt
+/server/node_modules
+
 # IDEs and editors
 .idea/
 .project

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "release:prepare": "npm run build && npm run changelog",
     "generate-release-notes": "node scripts/generate-release-notes.js",
     "vercel-build": "node scripts/vercel-build.js",
-    "build:prod": "ng build --configuration production"
+    "build:prod": "ng build --configuration production",
+    "build:coolify": "npm run build:prod && rm -rf server/public && mkdir -p server/public && cp -r dist/grocy-meal-planning/browser/. server/public/ && cd server && npm install && npm run build",
+    "start:coolify": "node server/.output/server/index.mjs"
   },
   "private": true,
   "dependencies": {

--- a/server/server/middleware/spa-fallback.ts
+++ b/server/server/middleware/spa-fallback.ts
@@ -1,0 +1,23 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const publicDir = join(process.cwd(), 'public');
+let cachedIndex: string | null = null;
+
+export default defineEventHandler((event) => {
+  const path = (event.path || '').split('?')[0];
+
+  if (path.startsWith('/api/')) return;
+  if (path.startsWith('/_')) return;
+  if (/\.[a-z0-9]+$/i.test(path)) return;
+  if (path === '/') return;
+
+  if (!cachedIndex) {
+    const indexPath = join(publicDir, 'index.html');
+    if (!existsSync(indexPath)) return;
+    cachedIndex = readFileSync(indexPath, 'utf-8');
+  }
+
+  setHeader(event, 'content-type', 'text/html; charset=utf-8');
+  return cachedIndex;
+});


### PR DESCRIPTION
## Summary
Migrate deployment from Vercel to self-hosted Coolify (Hetzner). Adds the minimal glue needed so a single Nuxt/Nitro Node server can serve the Angular SPA *and* the existing `/api/*` routes — no more Vercel build script and no more Vercel route rewrites required.

- `build:coolify` builds Angular (`build:prod`) → copies `dist/grocy-meal-planning/browser/*` into `server/public/` → builds Nuxt
- `start:coolify` boots `server/.output/server/index.mjs`
- `server/server/middleware/spa-fallback.ts` returns `index.html` for any non-API, extension-less path so deep links keep working without `vercel.json` rewrites
- `.gitignore` excludes the new build artifacts (`server/public`, `server/.output`, `server/.nuxt`)

`vercel.json` and `scripts/vercel-build.js` stay untouched so Vercel keeps working as a fallback during the cutover.

## Test plan
- [ ] Coolify build succeeds with custom commands (install / build / start)
- [ ] `https://grocy-meal-planning.disane.dev/` loads Angular SPA
- [ ] Deep-link `/recipes` (or any client route) returns the SPA, not 404
- [ ] `GET /api/fetch-recipe?url=…` works (existing endpoint)
- [ ] Vercel deployment still works on `main` until DNS is cut over